### PR TITLE
Add reference to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # TCP/IP Journey
 
-This placeholder will be filled after the analyzes are finished.
+This repository contains notes and analyses that I've made throughout my TCP/IP journey.
+To check out each individual study, you can refer to below:
+
+- [Study 1: Pinging Over a Remote Network](./1-ping/README.md)


### PR DESCRIPTION
The link to `ping` study is added to main README.
Since the disclaimers and details of the study were added to its own README, the main one is kept short.