### PR TITLE
Sync Application Layer notation (OSI-TCP/IP)

### DIFF
--- a/1-ping/2-dns.md
+++ b/1-ping/2-dns.md
@@ -55,7 +55,7 @@ So, how does this "name resolution" actually work?
 ## <a id='name-resolution-through-a-dns-server'/> Name Resolution Through a DNS Server
 
 Lets talk about DNS a little bit.
-DNS is a **L7 (Application Layer) Service** that allows us to find the IP address of a requested resource.
+DNS is a **L4 (Application Layer) Service** that allows us to find the IP address of a requested resource.
 Based on the implementation, it can leverage both of the **L4 (Transport layer) protocols TCP/UDP** and it's **well-defined port number is 53**.
 
 ---

--- a/1-ping/6-journey-on-gateway.md
+++ b/1-ping/6-journey-on-gateway.md
@@ -18,7 +18,7 @@
 Here is a quick rundown of what we have gone through in our analysis so far:
 
 - `ping` uses an L3 ICMP packet to test the connection with a specific host.
-- When a domain name is given to `ping`, it gets the IP address first via L7 DNS name resolution.
+- When a domain name is given to `ping`, it gets the IP address first via L4 DNS name resolution.
 - After getting the IP address, L3 IP checks the source and destination address and decides to forward the packet to the gateway of the network.
 - In order to physically move the packet to the gateway, L3 ARP is used to get the MAC address, then the packet is sent down to L2 to start the transmission.
 - L2 creates frames from the packet, and forwards it to L1 (Physical) to transmit the frames via the configured physical medium (wireless).

--- a/1-ping/README.md
+++ b/1-ping/README.md
@@ -39,7 +39,7 @@ Alright, let's see where this study takes us.
 Like it is mentioned above, `ping` is a Unix tool that is used to test a connection to a host.
 
 One of the important things about `ping` is that it uses _Internet Control Management Protocol_ (ICMP) packets to test the connection.
-This protocol lives on L3 of the _TCP/IP_ model (Network/Internet Layer), which allows our analysis to focus purely on the connection, unlike L7 protocols such as _HTTP/HTTPS_ or _FTP_.
+This protocol lives on L3 of the _TCP/IP_ model (Network/Internet Layer), which allows our analysis to focus purely on the connection, unlike L4 protocols such as _HTTP/HTTPS_ or _FTP_.
 Since ICMP lives on L3, it does not use _TCP_ or _UDP_ to function. It is encapsulated in a _IPv4_ packet.
 
 ICMP is mainly used to understand the _state_ of the transmitted packet. Based on the status of the remote location, ICMP can return messages like:


### PR DESCRIPTION
In some places the Application Layer was written with regard to the `OSI` model.
However, in some places it was written with regard to `TCP/IP`.

Therefore, the notation is synced.